### PR TITLE
Enable Plumber Score publishing and add badge

### DIFF
--- a/.github/workflows/plumber.yaml
+++ b/.github/workflows/plumber.yaml
@@ -8,18 +8,20 @@ on:
 permissions:
   contents: read
   security-events: write
+  id-token: write   # required to publish the Plumber Score
 
 jobs:
   plumber:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: getplumber/plumber@8ac17ed6234be680f0f339aeea27883a7f42ce92
+      - uses: getplumber/plumber@5302ddc7d9f1c9edb3f617bff04a09be452bcfe2 # v0.3.79
         with:
           threshold: "80"
           config-file: .plumber.yaml
           controls: actionsMustBePinnedByCommitSha,branchMustBeProtected
           score: "true"
+          score-push: "true"
           soft-fail: "true"
           upload-sarif: "true"
           upload-artifacts: "true"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![Quarkus](https://img.shields.io/badge/Quarkus-3.31.2-4695EB?logo=quarkus)
 ![Java](https://img.shields.io/badge/Java-25-ED8B00?logo=openjdk&logoColor=white)
 ![Javelit](https://img.shields.io/badge/Javelit-0.86.0-70FF9A)
+[![Plumber Score](https://score.getplumber.io/github.com/zenika-open-source/opensource-statistics.svg)](https://score.getplumber.io/github.com/zenika-open-source/opensource-statistics)
 
 🚧 This project is in progress ... 
 


### PR DESCRIPTION
Hi 👋

@Jagostini suggested I propose this 🙂

Plumber is already wired up here (nice!), but the Score wasn't actually being published: the pinned action (v0.3.30) predates score publishing, and `score: true` there only prints the letter score in the logs. So the README badge would have stayed empty.

This PR enables real score publishing and adds the badge:
- bumps the action to `v0.3.79` (pinned by SHA), which supports publishing
- adds `id-token: write` (required to mint the OIDC token, see https://getplumber.io/docs/plumber-score#-how-to-publish-with-github)
- adds `score-push: "true"`
- adds the Plumber Score badge in the README

All your other settings (threshold 80, controls, soft-fail, SARIF + artifacts upload) are kept as-is.

⚠️ Heads up: with score push on, the analysis result artifact (the full JSON with grade, metrics and per-control details) plus the repo name and score become public on `score.getplumber.io`. Example of what's published: https://getplumber.io/docs/plumber-score. If you'd rather not publish, just say so and I'll drop the badge + the `score-push`/`id-token` lines (publishing only happens on the default branch after merge anyway).

No pressure to merge, let me know what you think 🙏
