### PR TITLE
Update Plumber to v0.3.86 (security fix)

### DIFF
--- a/.github/workflows/plumber.yaml
+++ b/.github/workflows/plumber.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-      - uses: getplumber/plumber@5302ddc7d9f1c9edb3f617bff04a09be452bcfe2 # v0.3.79
+      - uses: getplumber/plumber@a697e9c316b058d279861719c73b87093fb5a60f # v0.3.86
         with:
           threshold: "80"
           config-file: .plumber.yaml


### PR DESCRIPTION
Hi 👋

I'm from the Plumber team. This repo pins the `getplumber/plumber` action in CI, and the version here is affected by a security issue we've just fixed (everything `<= 0.3.85`).

This PR bumps the pinned action to **v0.3.86** (SHA-pinned), which contains the fix.

We're not sharing the details publicly yet, a full advisory will be published soon. In the meantime we'd recommend updating promptly. Happy to answer anything.

Thanks! 🙏
