### PR TITLE
✨ Add project activity column

### DIFF
--- a/src/main/java/fr/zenika/opensource/stats/beans/Project.java
+++ b/src/main/java/fr/zenika/opensource/stats/beans/Project.java
@@ -15,6 +15,7 @@ public class Project {
     private Long forks;
     private String source;
     private String created_at;
+    private String lastActivityAt;
 
     public String getId() {
         return id;
@@ -102,6 +103,14 @@ public class Project {
 
     public void setCreated_at(String created_at) {
         this.created_at = created_at;
+    }
+
+    public String getLastActivityAt() {
+        return lastActivityAt;
+    }
+
+    public void setLastActivityAt(String lastActivityAt) {
+        this.lastActivityAt = lastActivityAt;
     }
 
     // Modern aliases if needed

--- a/src/main/java/fr/zenika/opensource/stats/beans/github/GitHubProject.java
+++ b/src/main/java/fr/zenika/opensource/stats/beans/github/GitHubProject.java
@@ -30,6 +30,11 @@ public class GitHubProject extends Project {
         this.setForks(forksCount);
     }
 
+    @JsonProperty("pushed_at")
+    public void setGitHubPushedAt(String pushedAt) {
+        this.setLastActivityAt(pushedAt);
+    }
+
     // Compatibility for existing code using specific GitHub names if needed
     // But we should ideally update the code to use the base class methods.
 

--- a/src/main/java/fr/zenika/opensource/stats/beans/gitlab/GitLabProject.java
+++ b/src/main/java/fr/zenika/opensource/stats/beans/gitlab/GitLabProject.java
@@ -35,6 +35,11 @@ public class GitLabProject extends Project {
         this.setForks(forksCount);
     }
 
+    @JsonProperty("last_activity_at")
+    public void setGitLabLastActivityAt(String lastActivityAt) {
+        this.setLastActivityAt(lastActivityAt);
+    }
+
     @JsonProperty("archived")
     public void setGitLabArchived(Object archived) {
         if (archived instanceof Boolean) {

--- a/src/main/java/fr/zenika/opensource/stats/mapper/ProjectMapper.java
+++ b/src/main/java/fr/zenika/opensource/stats/mapper/ProjectMapper.java
@@ -21,6 +21,7 @@ public class ProjectMapper {
         project.setArchived(Boolean.TRUE.equals(queryDocumentSnapshot.getBoolean("archived")));
         project.setVisibility(queryDocumentSnapshot.getString("visibility"));
         project.setCreated_at(queryDocumentSnapshot.getString("created_at"));
+        project.setLastActivityAt(queryDocumentSnapshot.getString("lastActivityAt"));
 
         return project;
     }
@@ -51,5 +52,6 @@ public class ProjectMapper {
         target.setArchived(source.isArchived());
         target.setVisibility(source.getVisibility());
         target.setCreated_at(source.getCreated_at());
+        target.setLastActivityAt(source.getLastActivityAt());
     }
 }

--- a/src/main/java/fr/zenika/opensource/stats/ui/tabs/ProjectsTab.java
+++ b/src/main/java/fr/zenika/opensource/stats/ui/tabs/ProjectsTab.java
@@ -15,6 +15,10 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,8 +41,8 @@ public class ProjectsTab {
     boolean syncButtonsEnabled;
 
     private String projectSearchTerm = "";
-    private String projectSortColumn = "Name";
-    private boolean projectSortAscending = true;
+    String projectSortColumn = "Name";
+    boolean projectSortAscending = true;
 
     public void render(JtContainer projectsTab) {
         try {
@@ -105,11 +109,12 @@ public class ProjectsTab {
                 sortProjects(filteredProjects);
 
                 record ProjectDisplay(String Name, String Full_Name, String URL, Long Stars, Long Forks,
-                        String Source) {
+                        String Source, String Activity) {
                 }
                 List<ProjectDisplay> rows = filteredProjects.stream()
                         .map(p -> new ProjectDisplay(p.getName(), p.getFull_name(), p.getHtml_url(),
-                                p.getWatchers_count(), p.getForks(), p.getSource()))
+                                p.getWatchers_count(), p.getForks(), p.getSource(),
+                                formatActivity(p.getLastActivityAt())))
                         .collect(Collectors.toList());
 
                 Jt.table(rows).key("member_projects_table").use(projectsTab);
@@ -134,6 +139,29 @@ public class ProjectsTab {
                 (p.getSource() != null && p.getSource().toLowerCase().contains(lowerTerm));
     }
 
+    private static final DateTimeFormatter ACTIVITY_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    String formatActivity(String lastActivityAt) {
+        Instant instant = parseInstant(lastActivityAt);
+        if (instant == null) {
+            return "Unknown";
+        }
+        String date = ACTIVITY_DATE_FORMAT.format(instant.atZone(ZoneOffset.UTC));
+        long days = ChronoUnit.DAYS.between(instant, Instant.now());
+        return days <= 30 ? "🔥 " + date : date;
+    }
+
+    Instant parseInstant(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Instant.parse(value);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
     private void toggleSort(String column) {
         if (projectSortColumn.equals(column)) {
             projectSortAscending = !projectSortAscending;
@@ -150,11 +178,14 @@ public class ProjectsTab {
         return column;
     }
 
-    private void sortProjects(List<Project> projects) {
+    void sortProjects(List<Project> projects) {
         Comparator<Project> comparator = switch (projectSortColumn) {
             case "Name" -> Comparator.comparing(p -> p.getName() != null ? p.getName().toLowerCase() : "");
             case "Stars" -> Comparator.comparing(p -> p.getWatchers_count() != null ? p.getWatchers_count() : 0L);
             case "Forks" -> Comparator.comparing(p -> p.getForks() != null ? p.getForks() : 0L);
+            case "Activity" -> Comparator.comparing(
+                    p -> parseInstant(p.getLastActivityAt()),
+                    Comparator.nullsFirst(Comparator.naturalOrder()));
             default -> Comparator.comparing(p -> p.getName() != null ? p.getName().toLowerCase() : "");
         };
 

--- a/src/test/java/fr/zenika/opensource/stats/beans/github/GitHubProjectTest.java
+++ b/src/test/java/fr/zenika/opensource/stats/beans/github/GitHubProjectTest.java
@@ -1,0 +1,34 @@
+package fr.zenika.opensource.stats.beans.github;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class GitHubProjectTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void deserialize_ShouldMapPushedAtToLastActivityAt() throws IOException {
+        String json = "{\"name\":\"test-project\",\"pushed_at\":\"2024-05-01T12:00:00Z\"}";
+
+        GitHubProject result = objectMapper.readValue(json, GitHubProject.class);
+
+        assertEquals("test-project", result.getName());
+        assertEquals("2024-05-01T12:00:00Z", result.getLastActivityAt());
+    }
+
+    @Test
+    void deserialize_WithoutPushedAt_ShouldLeaveLastActivityAtNull() throws IOException {
+        String json = "{\"name\":\"test-project\"}";
+
+        GitHubProject result = objectMapper.readValue(json, GitHubProject.class);
+
+        assertNull(result.getLastActivityAt());
+    }
+}

--- a/src/test/java/fr/zenika/opensource/stats/beans/gitlab/GitLabProjectTest.java
+++ b/src/test/java/fr/zenika/opensource/stats/beans/gitlab/GitLabProjectTest.java
@@ -1,0 +1,34 @@
+package fr.zenika.opensource.stats.beans.gitlab;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class GitLabProjectTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void deserialize_ShouldMapLastActivityAt() throws IOException {
+        String json = "{\"name\":\"test-project\",\"last_activity_at\":\"2024-05-01T12:00:00.000Z\"}";
+
+        GitLabProject result = objectMapper.readValue(json, GitLabProject.class);
+
+        assertEquals("test-project", result.getName());
+        assertEquals("2024-05-01T12:00:00.000Z", result.getLastActivityAt());
+    }
+
+    @Test
+    void deserialize_WithoutLastActivityAt_ShouldLeaveLastActivityAtNull() throws IOException {
+        String json = "{\"name\":\"test-project\"}";
+
+        GitLabProject result = objectMapper.readValue(json, GitLabProject.class);
+
+        assertNull(result.getLastActivityAt());
+    }
+}

--- a/src/test/java/fr/zenika/opensource/stats/mapper/ProjectMapperTest.java
+++ b/src/test/java/fr/zenika/opensource/stats/mapper/ProjectMapperTest.java
@@ -27,6 +27,7 @@ class ProjectMapperTest {
         when(mockDocument.getString("html_url")).thenReturn("https://github.com/zenika/test-project");
         when(mockDocument.getString("visibility")).thenReturn("public");
         when(mockDocument.getLong("watchers_count")).thenReturn(42L);
+        when(mockDocument.getString("lastActivityAt")).thenReturn("2024-05-01T12:00:00Z");
 
         // Act
         GitHubProject result = ProjectMapper.mapFirestoreProjectToGitHubProject(mockDocument);
@@ -41,6 +42,7 @@ class ProjectMapperTest {
         assertEquals("https://github.com/zenika/test-project", result.getHtml_url());
         assertEquals("public", result.getVisibility());
         assertEquals(42L, result.getWatchers_count());
+        assertEquals("2024-05-01T12:00:00Z", result.getLastActivityAt());
     }
 
     @Test
@@ -57,6 +59,7 @@ class ProjectMapperTest {
         when(mockDocument.getString("html_url")).thenReturn(null);
         when(mockDocument.getString("visibility")).thenReturn(null);
         when(mockDocument.getLong("watchers_count")).thenReturn(0L);
+        when(mockDocument.getString("lastActivityAt")).thenReturn(null);
 
         // Act
         GitHubProject result = ProjectMapper.mapFirestoreProjectToGitHubProject(mockDocument);
@@ -71,6 +74,7 @@ class ProjectMapperTest {
         assertNull(result.getHtml_url());
         assertNull(result.getVisibility());
         assertEquals(0L, result.getWatchers_count());
+        assertNull(result.getLastActivityAt());
     }
 
     @Test

--- a/src/test/java/fr/zenika/opensource/stats/ui/tabs/ProjectsTabTest.java
+++ b/src/test/java/fr/zenika/opensource/stats/ui/tabs/ProjectsTabTest.java
@@ -1,0 +1,97 @@
+package fr.zenika.opensource.stats.ui.tabs;
+
+import fr.zenika.opensource.stats.beans.Project;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProjectsTabTest {
+
+    private final ProjectsTab projectsTab = new ProjectsTab();
+
+    @Test
+    void formatActivity_WithRecentDate_ShouldPrefixWithFlame() {
+        String recent = Instant.now().minus(5, ChronoUnit.DAYS).toString();
+
+        String result = projectsTab.formatActivity(recent);
+
+        assertTrue(result.startsWith("🔥 "));
+    }
+
+    @Test
+    void formatActivity_WithOldDate_ShouldNotPrefixWithFlame() {
+        String old = Instant.now().minus(200, ChronoUnit.DAYS).toString();
+
+        String result = projectsTab.formatActivity(old);
+
+        assertFalse(result.startsWith("🔥"));
+    }
+
+    @Test
+    void formatActivity_WithNullDate_ShouldReturnUnknown() {
+        assertEquals("Unknown", projectsTab.formatActivity(null));
+    }
+
+    @Test
+    void formatActivity_WithUnparseableDate_ShouldReturnUnknown() {
+        assertEquals("Unknown", projectsTab.formatActivity("not-a-date"));
+    }
+
+    @Test
+    void parseInstant_WithValidIsoString_ShouldReturnInstant() {
+        Instant instant = projectsTab.parseInstant("2024-05-01T12:00:00Z");
+
+        assertEquals(Instant.parse("2024-05-01T12:00:00Z"), instant);
+    }
+
+    @Test
+    void parseInstant_WithBlankOrInvalid_ShouldReturnNull() {
+        assertNull(projectsTab.parseInstant(null));
+        assertNull(projectsTab.parseInstant(""));
+        assertNull(projectsTab.parseInstant("not-a-date"));
+    }
+
+    @Test
+    void sortProjects_ByActivity_ShouldOrderOldestFirstWithNullsFirst() {
+        Project noActivity = projectWithActivity(null);
+        Project older = projectWithActivity(Instant.now().minus(300, ChronoUnit.DAYS).toString());
+        Project recent = projectWithActivity(Instant.now().minus(1, ChronoUnit.DAYS).toString());
+
+        List<Project> projects = new ArrayList<>(List.of(recent, noActivity, older));
+        projectsTab.projectSortColumn = "Activity";
+        projectsTab.projectSortAscending = true;
+
+        projectsTab.sortProjects(projects);
+
+        assertEquals(List.of(noActivity, older, recent), projects);
+    }
+
+    @Test
+    void sortProjects_ByActivityDescending_ShouldOrderMostRecentFirst() {
+        Project older = projectWithActivity(Instant.now().minus(300, ChronoUnit.DAYS).toString());
+        Project recent = projectWithActivity(Instant.now().minus(1, ChronoUnit.DAYS).toString());
+
+        List<Project> projects = new ArrayList<>(List.of(older, recent));
+        projectsTab.projectSortColumn = "Activity";
+        projectsTab.projectSortAscending = false;
+
+        projectsTab.sortProjects(projects);
+
+        assertEquals(List.of(recent, older), projects);
+    }
+
+    private Project projectWithActivity(String lastActivityAt) {
+        Project project = new Project();
+        project.setLastActivityAt(lastActivityAt);
+        return project;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `lastActivityAt` to `Project` (populated from GitHub's `pushed_at` and GitLab's `last_activity_at`)
- Display it in the Members Projects table, prefixed with 🔥 when within the last 30 days
- Extend Firestore mapping (`ProjectMapper`) to persist/read the new field, add `Activity` sort case

## Why not commit count
Considered showing commit count instead of a date, but skipped it:
- GitHub doesn't expose commit count in the repo listing endpoint; would require one extra API call per repo (Link-header last-page trick)
- GitLab's `statistics.commit_count` requires `?statistics=true` plus elevated project permissions, not guaranteed to work for arbitrary members' repos
- `pushed_at` / `last_activity_at` are already included in the existing API responses, zero extra calls

## Test plan
1. Open Projects tab
2. Confirm the activity column