### PR TITLE
🐛 Fix member selectbox reverting to default option

### DIFF
--- a/src/main/java/fr/zenika/opensource/stats/ui/tabs/ContributionsTab.java
+++ b/src/main/java/fr/zenika/opensource/stats/ui/tabs/ContributionsTab.java
@@ -229,10 +229,17 @@ public class ContributionsTab {
                                                         m -> m.getId(),
                                                         (existing, replacement) -> existing));
 
+                        List<String> memberLabels = memberOptions.keySet().stream().sorted()
+                                        .collect(Collectors.toList());
+
+                        Object previousSelection = Jt.componentsState().get("member_selection");
+                        int previousIndex = previousSelection != null
+                                        ? memberLabels.indexOf(previousSelection.toString())
+                                        : -1;
+
                         selectedMemberLabel = Jt
-                                        .selectbox("Select a member",
-                                                        new ArrayList<>(memberOptions.keySet().stream().sorted()
-                                                                        .collect(Collectors.toList())))
+                                        .selectbox("Select a member", new ArrayList<>(memberLabels))
+                                        .index(previousIndex >= 0 ? previousIndex : 0)
                                         .key("member_selection")
                                         .use(individualRow.col(0));
                 } catch (Exception e) {


### PR DESCRIPTION
## Summary
- The "Select a member" dropdown in Contributions > Individual Member Stats always rendered with `index=0`, its static builder default, instead of the persisted selection.
- Any rerun triggered elsewhere on the page (year change, sync button, ...) visually snapped the dropdown back to the first member, even though a different one had been selected.
- The previous selection is now read from `Jt.componentsState()` and passed back via `.index(...)`, mirroring the pattern already used by `yearValue` (`.value(Year.now().getValue())`).

## Test plan
1. Open Contributions tab, pick a member other than the first in the list
2. Trigger a rerun (change the year, or click another widget on the page)
3. Confirm the dropdown still shows the previously selected member
